### PR TITLE
Remove accidentally left code snippet

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -51,5 +51,4 @@ jobs:
               --exclude reports \
               --show-deprecated \
               --checkstyle | \
-            cs2pr \
-          || echo "### No changed PHP files" >> $GITHUB_STEP_SUMMARY
+            cs2pr


### PR DESCRIPTION
The lint test returns always success. Does not stop the following checkstyle running.

It generates zero exit code for the test.
There is already a guard to run the test only if it has changed `.php` file.